### PR TITLE
Use HTTPS for imageURL

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ app.post("/weather", (req,res) => {
             temperature = weatherData.main.temp;
             weatherDescription = weatherData.weather[0].description;
             weatherImage = weatherData.weather[0].icon;
-            imageURL = "http://openweathermap.org/img/wn/" + weatherImage + "@2x.png";
+            imageURL = "https://openweathermap.org/img/wn/" + weatherImage + "@2x.png";
             weatherHumidity = weatherData.main.humidity;
 
             res.render("result", {


### PR DESCRIPTION
The endpoint for the weather image supports HTTPS so it should be used instead of HTTP. Additionally, since the app is currently only being hosted an HTTPS-only server, serving this image over HTTP causes a warning to be logged to the browser console regarding [mixed content](https://web.dev/what-is-mixed-content/).

This pull request modifies the weather image URL to resolve this issue.